### PR TITLE
Update 'Release' configuration to match the 'Debug' config

### DIFF
--- a/Samples/DPIAwarenessPerWindow/cpp/DpiAwarenessContext.vcxproj
+++ b/Samples/DPIAwarenessPerWindow/cpp/DpiAwarenessContext.vcxproj
@@ -155,8 +155,14 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Manifest>
-      <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
+      <EnableDpiAwareness>
+      </EnableDpiAwareness>
+      <AdditionalManifestFiles>$(TargetName)$(TargetExt).manifest</AdditionalManifestFiles>
+      <OutputManifestFile>$(IntDir)$(TargetName)$(TargetExt).embed.manifest</OutputManifestFile>
     </Manifest>
+    <ManifestResourceCompile>
+      <ResourceOutputFileName>$(IntDir)$(TargetName)$(TargetExt).embed.manifest.res</ResourceOutputFileName>
+    </ManifestResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="Resource.h" />


### PR DESCRIPTION
More specifically, I made the manifest settings for the release version match the manifest settings for the debug version.

Otherwise, versions built with the release config show up with comctlv5.

The release config produces a binary that only requires the Visual Studio Runtime to run on another app, whereas the debug config produces one that needs a bit more stuff.
