### PR TITLE
Fix empty composition string handling of immpad sample

### DIFF
--- a/Samples/Win7Samples/winui/input/tsf/tsfapps/immpad-level3-step3/TextContainer.cpp
+++ b/Samples/Win7Samples/winui/input/tsf/tsfapps/immpad-level3-step3/TextContainer.cpp
@@ -11,7 +11,10 @@
 
 BOOL CTextContainer::InsertText(int nPos, const WCHAR *psz, UINT nCnt)
 {
-    if (_nTextSize + nCnt > 0 && !EnsureBuffer(_nTextSize + nCnt))
+    if (nCnt == 0)
+        return TRUE;
+    
+    if (!EnsureBuffer(_nTextSize + nCnt))
     {
         return FALSE;
     }

--- a/Samples/Win7Samples/winui/input/tsf/tsfapps/immpad-level3-step3/TextContainer.cpp
+++ b/Samples/Win7Samples/winui/input/tsf/tsfapps/immpad-level3-step3/TextContainer.cpp
@@ -11,7 +11,7 @@
 
 BOOL CTextContainer::InsertText(int nPos, const WCHAR *psz, UINT nCnt)
 {
-    if (!EnsureBuffer(_nTextSize + nCnt))
+    if (_nTextSize + nCnt > 0 && !EnsureBuffer(_nTextSize + nCnt))
     {
         return FALSE;
     }

--- a/Samples/Win7Samples/winui/input/tsf/tsfapps/immpad-level3-step3/TextInputCtrl.cpp
+++ b/Samples/Win7Samples/winui/input/tsf/tsfapps/immpad-level3-step3/TextInputCtrl.cpp
@@ -195,7 +195,7 @@ LRESULT CALLBACK CTextInputCtrl::s_WndProc(HWND hwnd, UINT message, WPARAM wPara
                     LONG lAttrSize = ImmGetCompositionString(himc, GCS_COMPATTR, NULL, 0);
                     LONG lClauseInfoSize = ImmGetCompositionString(himc, GCS_COMPCLAUSE, NULL, 0);
 
-                    if (lSize)
+                    if (lSize >= 0)
                     {
                         BYTE *prgAttr = NULL;
                         LONG *prgClauseInfo = NULL;
@@ -209,7 +209,7 @@ LRESULT CALLBACK CTextInputCtrl::s_WndProc(HWND hwnd, UINT message, WPARAM wPara
 
                         if (psz)
                         {
-                            if (ImmGetCompositionString(himc, GCS_COMPSTR, psz, lSize))
+                            if (ImmGetCompositionString(himc, GCS_COMPSTR, psz, lSize) == lSize)
                             {
                                 if (prgAttr)
                                 {


### PR DESCRIPTION
The composition string actually can be empty and the code does not handle it correctly. If you try to delete the last char in the composition string, you'll find that char become a normal char.

This commit only fixes level3-step3. Maybe we also need to fix others there.