### PR TITLE
Fixed a bug in ltguid comparison

### DIFF
--- a/Samples/Win7Samples/winbase/vss/vshadow/util.h
+++ b/Samples/Win7Samples/winbase/vss/vshadow/util.h
@@ -693,7 +693,7 @@ struct ltguid
     bool operator()(GUID guid1, GUID guid2) const
     {
         return (guid1.Data1 < guid2.Data1) ||
-               (guid1.Data1 == guid2.Data1 && guid1.Data2 < guid1.Data2) ||
+               (guid1.Data1 == guid2.Data1 && guid1.Data2 < guid2.Data2) ||
                (guid1.Data1 == guid2.Data1 && guid1.Data2 == guid2.Data2 && guid1.Data3 < guid2.Data3);
     }
 };


### PR DESCRIPTION
Probably a copy-paste mistake which caused the comparison to compare the guid1 with itself instead of guid2.