### PR TITLE
Multithreaded issue on MFTransformDecoder

### DIFF
--- a/Samples/MediaFoundationTransformDecoder/cpp/CHWMFT.cpp
+++ b/Samples/MediaFoundationTransformDecoder/cpp/CHWMFT.cpp
@@ -607,6 +607,8 @@ HRESULT CHWMFT::RequestSample(
         ** we know m_pEventQueue can never be
         ** NULL due to InitializeTransform()
         ***************************************/
+        
+        CAutoLock lock(&m_csLock);
 
         hr = m_pEventQueue->QueueEvent(pEvent);
         if(FAILED(hr))
@@ -615,8 +617,6 @@ HRESULT CHWMFT::RequestSample(
         }
 
         {
-            CAutoLock lock(&m_csLock);
-
             m_dwNeedInputCount++;
 
             TraceString(CHMFTTracing::TRACE_INFORMATION, L"%S(): NeedInputCount: %u",  __FUNCTION__, m_dwNeedInputCount);


### PR DESCRIPTION
If you do not lock CHWMFT before m_pEventQueue->QueueEvent in RequestSample, ProcessInput can be call before m_dwNeedInputCount++.  ProcessInput will have m_dwNeedInputCount == 0, and will return MF_E_NOTACCEPTING. The client will never call ProcessInput after, and the transform will stop generate samples.