### PR TITLE
MediaFoundationTransformDecoder avoid out of memory

### DIFF
--- a/Samples/MediaFoundationTransformDecoder/cpp/CHWMFT.cpp
+++ b/Samples/MediaFoundationTransformDecoder/cpp/CHWMFT.cpp
@@ -588,6 +588,13 @@ HRESULT CHWMFT::RequestSample(
                 hr = MF_E_NOTACCEPTING;
                 break;
             }
+            
+            // Stop sending METransformNeedInput, because we have MAX output.
+            // Let client process output before sending METransformNeedInput agaain
+            if(m_pOutputSampleQueue->GetSampleCount() >= MFT_MAX_OUTPUT_STOP_NEED_INPUT)
+			{
+				break;
+			}
         }
 
         hr = MFCreateMediaEvent(METransformNeedInput, GUID_NULL, S_OK, NULL, &pEvent);

--- a/Samples/MediaFoundationTransformDecoder/cpp/CHWMFT.h
+++ b/Samples/MediaFoundationTransformDecoder/cpp/CHWMFT.h
@@ -11,6 +11,8 @@
 #define MFT_FRAMERATE_DENOMINATOR   1
 #define MFT_DEFAULT_SAMPLE_DURATION 300000 // 1/30th of a second in hundred nanoseconds
 
+#define MFT_MAX_OUTPUT_STOP_NEED_INPUT    5 // Stop sending need input when output equal max value
+
 enum eMFTStatus
 {
     MYMFT_STATUS_INPUT_ACCEPT_DATA      = 0x00000001,   /* The MFT can accept input data */

--- a/Samples/MediaFoundationTransformDecoder/cpp/CHWMFT_IMFTransform_Impl.cpp
+++ b/Samples/MediaFoundationTransformDecoder/cpp/CHWMFT_IMFTransform_Impl.cpp
@@ -1020,6 +1020,17 @@ HRESULT CHWMFT::ProcessOutput(
             {
                 m_dwHaveOutputCount--;
             }
+
+            // Ask for input sample
+			if(m_dwHaveOutputCount < MFT_MAX_OUTPUT_STOP_NEED_INPUT)
+			{
+				hr = RequestSample(0);
+
+				if(FAILED(hr))
+				{
+					break;
+				}
+			}
         }
 
         /*****************************************

--- a/Samples/MediaFoundationTransformDecoder/cpp/CSampleQueue.cpp
+++ b/Samples/MediaFoundationTransformDecoder/cpp/CSampleQueue.cpp
@@ -288,6 +288,24 @@ BOOL CSampleQueue::IsQueueEmpty(void)
     return (m_pHead == NULL) ? TRUE : FALSE;
 }
 
+DWORD CSampleQueue::GetSampleCount(){
+
+	DWORD dwCount = 0;
+	CNode* pHead;
+
+	CAutoLock lock(&m_csLock);
+
+	pHead = m_pHead;
+
+	while(pHead)
+	{
+		dwCount++;
+		pHead = pHead->pNext;
+	}
+
+	return dwCount;
+}
+
 CSampleQueue::CSampleQueue(void)
 {
     m_ulRef         = 1;

--- a/Samples/MediaFoundationTransformDecoder/cpp/CSampleQueue.h
+++ b/Samples/MediaFoundationTransformDecoder/cpp/CSampleQueue.h
@@ -35,6 +35,7 @@ public:
                             const ULONG_PTR pulID
                             );
             BOOL    IsQueueEmpty(void);
+            DWORD GetSampleCount();
 
 protected:
                 class CNode;


### PR DESCRIPTION
This program always send METransformNeedInput when an input sample is processed.

The problem of this approach is that METransformNeedInput will be generated more than METransformHaveOutput. You will quickly face out of memory, because a lot of output sample will be created (on Windows Seven).

This patch is just a simple workaround. See MFT_MAX_OUTPUT_STOP_NEED_INPUT.