### PR TITLE
Added  FILE_SHARE_WRITE & FILE_SHARE_DELETE To DirectoryWatcher in CloudMirro sample

### DIFF
--- a/Samples/CloudMirror/CloudMirror/DirectoryWatcher.cpp
+++ b/Samples/CloudMirror/CloudMirror/DirectoryWatcher.cpp
@@ -23,7 +23,7 @@ void DirectoryWatcher::Initalize(
 
     _dir.attach(CreateFile(path,
         FILE_LIST_DIRECTORY,
-        FILE_SHARE_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
         nullptr,
         OPEN_EXISTING,
         FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,


### PR DESCRIPTION
The HANDLE that is used with the `ReadDirectoryChangesW` was created only with `FILE_SHARE_READ`. This prevents moving files in the directory, since the HANDLE does not allow writes.