### PR TITLE
Fix leap year bugs in samples

### DIFF
--- a/Samples/Win7Samples/security/adrms/consumption/Consumption.cpp
+++ b/Samples/Win7Samples/security/adrms/consumption/Consumption.cpp
@@ -2341,7 +2341,16 @@ wmain(
 	//
 	GetSystemTime( &stTimeFrom );
 	GetSystemTime( &stTimeUntil );
-	stTimeUntil.wYear++;
+
+    FILETIME ft = { 0 };
+    SystemTimeToFileTime(&stTimeUntil, &ft);
+
+    ULARGE_INTEGER u = { 0 };
+    memcpy(&u, &ft, sizeof(u));
+    u.QuadPart += 90 * 24 * 60 * 60 * 10000000LLU;  // 90 days
+    memcpy(&ft, &u, sizeof(ft));
+
+    FileTimeToSystemTime(&ft, &stTimeUntil);
 
 	//
 	// 13. Create an unsigned issuance license from scratch

--- a/Samples/Win7Samples/security/adrms/offlinepublishing/OfflinePublishing.cpp
+++ b/Samples/Win7Samples/security/adrms/offlinepublishing/OfflinePublishing.cpp
@@ -1636,7 +1636,16 @@ wmain(
     //
     GetSystemTime( &stTimeFrom );
     GetSystemTime( &stTimeUntil );
-    stTimeUntil.wYear++;
+    
+    FILETIME ft = { 0 };
+    SystemTimeToFileTime(&stTimeUntil, &ft);
+
+    ULARGE_INTEGER u = { 0 };
+    memcpy(&u, &ft, sizeof(u));
+    u.QuadPart += 90 * 24 * 60 * 60 * 10000000LLU;  // 90 days
+    memcpy(&ft, &u, sizeof(ft));
+
+    FileTimeToSystemTime(&ft, &stTimeUntil);
 
     //
     // 12. Create an unsigned issuance license from scratch

--- a/Samples/Win7Samples/security/adrms/onlinepublishing/OnlinePublishing.cpp
+++ b/Samples/Win7Samples/security/adrms/onlinepublishing/OnlinePublishing.cpp
@@ -439,7 +439,16 @@ wmain(
     //
     GetSystemTime( &stTimeFrom );
     GetSystemTime( &stTimeUntil );
-    stTimeUntil.wYear++;
+    
+    FILETIME ft = { 0 };
+    SystemTimeToFileTime(&stTimeUntil, &ft);
+
+    ULARGE_INTEGER u = { 0 };
+    memcpy(&u, &ft, sizeof(u));
+    u.QuadPart += 90 * 24 * 60 * 60 * 10000000LLU;  // 90 days
+    memcpy(&ft, &u, sizeof(ft));
+
+    FileTimeToSystemTime(&ft, &stTimeUntil);
 
     // 
     // 2. Create an issuance license, user, and right.  Add the right/user

--- a/Samples/Win7Samples/security/adrms/publishingacl/PublishingACL.cpp
+++ b/Samples/Win7Samples/security/adrms/publishingacl/PublishingACL.cpp
@@ -468,7 +468,16 @@ wmain(
     //
     GetSystemTime( &stTimeFrom );
     GetSystemTime( &stTimeUntil );
-    stTimeUntil.wYear++;
+    
+    FILETIME ft = { 0 };
+    SystemTimeToFileTime(&stTimeUntil, &ft);
+
+    ULARGE_INTEGER u = { 0 };
+    memcpy(&u, &ft, sizeof(u));
+    u.QuadPart += 90 * 24 * 60 * 60 * 10000000LLU;  // 90 days
+    memcpy(&ft, &u, sizeof(ft));
+
+    FileTimeToSystemTime(&ft, &stTimeUntil);
 
     //
     // 1. Create an unsigned issuance license from scratch

--- a/Samples/Win7Samples/winui/sideshow/alarms/AlarmClient.cpp
+++ b/Samples/Win7Samples/winui/sideshow/alarms/AlarmClient.cpp
@@ -152,10 +152,19 @@ void CAlarmClient::ShowNotification(Alarm* pAlarm)
         }
 
         //
-        // Set the Notification to expire after 1 year
+        // Set the Notification to expire after 90 days
         //
         ::GetLocalTime(&expTime);
-        expTime.wYear++;
+
+        FILETIME ft = { 0 };
+        SystemTimeToFileTime(&expTime, &ft);
+
+        ULARGE_INTEGER u = { 0 };
+        memcpy(&u, &ft, sizeof(u));
+        u.QuadPart += 90 * 24 * 60 * 60 * 10000000LLU;  // 90 days
+        memcpy(&ft, &u, sizeof(ft));
+
+        FileTimeToSystemTime(&ft, &expTime);
 
         hr = m_pNotification->put_ExpirationTime(&expTime);
         if (FAILED(hr))


### PR DESCRIPTION
Various samples exhibit a leap year bug where the `.wYear` field of a `SYSTEMTIME` struct is incremented without regard for overall validity of the computed date.  In other words, adding a year to `2020-02-29` should not be `2021-02-29` since that date doesn't exist.

This PR fixes those that I found in this repo, by adjusting such dates back to Feb 28th.