### PR TITLE
[BUG] RowsetViewer. Incorrect value of pwszReserved  in call of IData…

### DIFF
--- a/Samples/Win7Samples/dataaccess/oledb/rowsetviewer/cdatalinks.cpp
+++ b/Samples/Win7Samples/dataaccess/oledb/rowsetviewer/cdatalinks.cpp
@@ -150,8 +150,8 @@ HRESULT CServiceComp::CreateDBInstance(REFCLSID clsid, CAggregate* pCAggregate, 
 	if(m_pIDataInitialize)
 	{
 		//Now Obtain Instance of Provider (with Service Components)
-		XTEST(hr = m_pIDataInitialize->CreateDBInstance(clsid, pCAggregate, dwCLSCTX, L"pwszReserved", riid, ppIUnknown));
-		TESTC(TRACE_METHOD(hr, L"IDataInitialize::CreateDBInstance(%s, 0x%p, 0x%08x, \"pwszReserved\", %s, &0x%p)", pwszProgID, pCAggregate, dwCLSCTX, GetInterfaceName(riid), ppIUnknown ? *ppIUnknown : NULL));
+		XTEST(hr = m_pIDataInitialize->CreateDBInstance(clsid, pCAggregate, dwCLSCTX, NULL, riid, ppIUnknown));
+		TESTC(TRACE_METHOD(hr, L"IDataInitialize::CreateDBInstance(%s, 0x%p, 0x%08x, NULL, %s, &0x%p)", pwszProgID, pCAggregate, dwCLSCTX, GetInterfaceName(riid), ppIUnknown ? *ppIUnknown : NULL));
 
 		//Handle Aggregation
 		if(pCAggregate)


### PR DESCRIPTION
…Initialize::CreateDBInstance

OLE DB RowsetViewer calls IDataInitialize::CreateDBInstance with pwszReserved=L"pwszReserved"

OLE DB References says about pwszReserved parameter:

pwszReserved [in]
Reserved for future use; must be NULL.

https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms723098(v%3Dvs.85)

It is creates problem with alternative implementation of IDataInitialize interface, which has strong verification for this parameter.