### PR TITLE
Fix horizontal scrolling redirecting WM_MOUSEHWHEEL to ProcessInput()

### DIFF
--- a/Samples/TouchInputDirectManipulation/cpp/AppWindow.cpp
+++ b/Samples/TouchInputDirectManipulation/cpp/AppWindow.cpp
@@ -259,6 +259,7 @@ namespace DManipSample
             break;
         case WM_KEYDOWN:
         case WM_MOUSEWHEEL:
+        case WM_MOUSEHWHEEL:
             {
                 DWORD targetContact = (message == WM_KEYDOWN) ? DIRECTMANIPULATION_KEYBOARDFOCUS : DIRECTMANIPULATION_MOUSEFOCUS;
                 BOOL fHandled = FALSE;  


### PR DESCRIPTION
Without this patch we cannot pan the viewport horizontally.