### PR TITLE
Document presumed race condition in MFCaptureD3D

### DIFF
--- a/Samples/Win7Samples/multimedia/mediafoundation/MFCaptureD3D/device.cpp
+++ b/Samples/Win7Samples/multimedia/mediafoundation/MFCaptureD3D/device.cpp
@@ -348,7 +348,7 @@ done:
 void DrawDevice::UpdateDestinationRect()
 {
     RECT rcClient;
-    RECT rcSrc = { 0, 0, m_width, m_height };
+    RECT rcSrc = { 0, 0, static_cast<LONG>(m_width), static_cast<LONG>(m_height) };
 
     GetClientRect(m_hwnd, &rcClient);
 

--- a/Samples/Win7Samples/multimedia/mediafoundation/MFCaptureD3D/preview.cpp
+++ b/Samples/Win7Samples/multimedia/mediafoundation/MFCaptureD3D/preview.cpp
@@ -189,6 +189,7 @@ HRESULT CPreview::OnReadSample(
 
     if (FAILED(hrStatus))
     {
+        // Error is raised here, e.g. hrStatus == 0xC00D3EA2, "The video recording device is no longer present"
         hr = hrStatus;
     }
 
@@ -224,6 +225,7 @@ HRESULT CPreview::OnReadSample(
 
     if (FAILED(hr))
     {
+        // Post the error to the application, which displays a message box.
         NotifyError(hr);
     }
     SafeRelease(&pBuffer);
@@ -398,6 +400,10 @@ HRESULT CPreview::SetDevice(IMFActivate *pActivate)
     if (SUCCEEDED(hr))
     {
         // Ask for the first sample.
+        //
+        // After this first call to ReadSample,
+        // MF will call call CPreview::OnReadSample with an error,
+        // such as 0xC00D3EA2 "The video recording device is no longer present".
         hr = m_pReader->ReadSample(
             (DWORD)MF_SOURCE_READER_FIRST_VIDEO_STREAM,
             0,

--- a/Samples/Win7Samples/multimedia/mediafoundation/MFCaptureD3D/winmain.cpp
+++ b/Samples/Win7Samples/multimedia/mediafoundation/MFCaptureD3D/winmain.cpp
@@ -415,6 +415,10 @@ void OnChooseDevice(HWND hwnd, BOOL bPrompt)
             bCancel = TRUE; // User cancelled
         }
     }
+    else {
+        // This increases chances of success.
+        Sleep(5000);
+    }
 
     if (!bCancel && (param.count > 0))
     {


### PR DESCRIPTION
To see the bug I refer to, just run the MFCaptureD3D example. 

The expected behavior, as the demo clearly shows, is that it immediately starts displaying the feed from the first video source (webcam).

The actual behavior, most of the time, is an error, such as `0xC00D3EA2`, "The video recording device is no longer present".

The debug log then contains a line like:

```
Exception thrown at 0x751B4192 (KernelBase.dll) in MFCaptureD3D.exe: WinRT originate error - 0x800701B1 : 'A device which does not exist was specified.'.
```

The error is raised by Media Foundation after calling `IMFSourceReader::ReadSample`. This example uses `IMFSourceReader` asynchronously, so the error comes back in the `OnReadSample` callback.

This error usually does _not_ occur when selecting the webcam from the menu. Adding a `Sleep` increases chances of success. I am therefore guessing that there is some kind of race condition happening here.

There are several different errors that I have seen raised, including `0xC00D3EA2`, `0x800701B1`, `0xC00D3E9B` and `0x80070003`. I guess these are due to multiple different race conditions.

The `MFCaptureToFile` sample has the same problem. After clicking "Start Capture", an error is logged, like:

```
Exception thrown at 0x751B4192 (KernelBase.dll) in MFCaptureToFile.exe: WinRT originate error - 0xC00D3EA2 : 'The video recording device is no longer present.'
```