### PR TITLE
Fix MFCaptureD3D bug: unsupported format causes infinite loop

### DIFF
--- a/Samples/Win7Samples/multimedia/mediafoundation/MFCaptureD3D/preview.cpp
+++ b/Samples/Win7Samples/multimedia/mediafoundation/MFCaptureD3D/preview.cpp
@@ -266,7 +266,8 @@ HRESULT CPreview::TryMediaType(IMFMediaType *pType)
         for (DWORD i = 0;  ; i++)
         {
             // Get the i'th format.
-            m_draw.GetFormat(i, &subtype);
+            hr = m_draw.GetFormat(i, &subtype);
+            if (FAILED(hr)) { break; }
 
             hr = pType->SetGUID(MF_MT_SUBTYPE, subtype);
             


### PR DESCRIPTION
If GetFormat reaches the end of its internal array, it returns an error indicating so. However, the caller ignores this returned error and continues looking for more formats.

To reproduce the error, remove entries from `g_FormatConversions` in `device.cpp`.