### PR TITLE
Minimal changes to repro the cloud file API bug: AckDelete is broken on Win10 2004.

### DIFF
--- a/Samples/CloudMirror/CloudMirror/FakeCloudProvider.cpp
+++ b/Samples/CloudMirror/CloudMirror/FakeCloudProvider.cpp
@@ -39,6 +39,7 @@ CF_CALLBACK_REGISTRATION FakeCloudProvider::s_MirrorCallbackTable[] =
 {
     { CF_CALLBACK_TYPE_FETCH_DATA, FakeCloudProvider::OnFetchData },
     { CF_CALLBACK_TYPE_CANCEL_FETCH_DATA, FakeCloudProvider::OnCancelFetchData },
+	{ CF_CALLBACK_TYPE_NOTIFY_DELETE, FakeCloudProvider::OnNotifyDelete},
     CF_CALLBACK_REGISTRATION_END
 };
 
@@ -102,6 +103,17 @@ void CALLBACK FakeCloudProvider::OnCancelFetchData(
     _In_ CONST CF_CALLBACK_PARAMETERS* callbackParameters)
 {
     FileCopierWithProgress::CancelCopyFromServerToClient(callbackInfo, callbackParameters);
+}
+
+void CALLBACK FakeCloudProvider::OnNotifyDelete(
+    _In_ CONST CF_CALLBACK_INFO* callbackInfo,
+    _In_ CONST CF_CALLBACK_PARAMETERS* callbackParameters)
+{
+	// ------------------------ [Bug Repro]-----------------------------------------
+	// STATUS_UNSUCCESSFUL should fail user's action, prevent file from being deleted,
+	// but on Win10 2004, file got deleted anyway.
+	// Win10 versions before 2004 behave as expected, error message box popup, file is untouched.
+    FileCopierWithProgress::AckDelete(callbackInfo->ConnectionKey, callbackInfo->TransferKey, STATUS_UNSUCCESSFUL);
 }
 
 // Registers the callbacks in the table at the top of this file so that the methods above

--- a/Samples/CloudMirror/CloudMirror/FakeCloudProvider.h
+++ b/Samples/CloudMirror/CloudMirror/FakeCloudProvider.h
@@ -24,7 +24,11 @@ private:
     static void CALLBACK OnCancelFetchData(
         _In_ CONST CF_CALLBACK_INFO* callbackInfo,
         _In_ CONST CF_CALLBACK_PARAMETERS* callbackParameters);
-
+	
+    static void CALLBACK OnNotifyDelete(
+        _In_ CONST CF_CALLBACK_INFO* callbackInfo,
+        _In_ CONST CF_CALLBACK_PARAMETERS* callbackParameters);
+	
 private:
     static CF_CONNECTION_KEY s_transferCallbackConnectionKey;
     static CF_CALLBACK_REGISTRATION s_MirrorCallbackTable[];

--- a/Samples/CloudMirror/CloudMirror/FileCopierWithProgress.h
+++ b/Samples/CloudMirror/CloudMirror/FileCopierWithProgress.h
@@ -19,6 +19,11 @@ public:
         _In_ CONST CF_CALLBACK_INFO* callbackInfo,
         _In_ CONST CF_CALLBACK_PARAMETERS* callbackParameters);
 
+    static void AckDelete(
+        CF_CONNECTION_KEY connectionKey,
+        LARGE_INTEGER transferKey,
+        NTSTATUS completionStatus);
+
 private:
     static void CopyFromServerToClientWorker(
         _In_ CONST CF_CALLBACK_INFO* callbackInfo,


### PR DESCRIPTION
```STATUS_UNSUCCESSFUL``` should fail user's action, prevent file from being deleted,
but on Win10 2004, file got deleted anyway.
On Win10 versions before 2004, it behave as expected, error message box popup, file is untouched.