### PR TITLE
Fix memory leak in ResetDataContext

### DIFF
--- a/Samples/Win7Samples/winbase/Eventing/EtwConsumer/TdhUtil.cpp
+++ b/Samples/Win7Samples/winbase/Eventing/EtwConsumer/TdhUtil.cpp
@@ -955,7 +955,7 @@ Return Value:
     }
     
     if (DataContext->RenderItems != NULL) {
-        for(LONG Index = 0; Index < DataContext->CurrentTopLevelIndex; Index++) {
+        for(ULONG Index = 0; Index < DataContext->RenderItemsCount; Index++) {
             if (DataContext->RenderItems[Index] != NULL) {
                 free(DataContext->RenderItems[Index]);
             }


### PR DESCRIPTION
`CurrentTopLevelIndex` starts at -1, so the loop should go to `CurrentTopLevelIndex + 1`. However, it was already fixed internally like this.