### PR TITLE
Fix LSP sample to install correctly on 64-bit machines

### DIFF
--- a/Samples/Win7Samples/netds/winsock/lsp/install/instlsp.cpp
+++ b/Samples/Win7Samples/netds/winsock/lsp/install/instlsp.cpp
@@ -237,7 +237,7 @@ int _cdecl main(int argc, char *argv[])
             case 'd':               // Full path and filename to LSP
                 if ( i+1 >= argc )
                     goto cleanup;
-                if (_strnicmp(argv[i], "-d32", 4))
+                if (!_strnicmp(argv[i], "-d32", 4))
                     lpszLspPathAndFile32 = argv[ ++i ];
                 else
                     lpszLspPathAndFile = argv[ ++i ];
@@ -340,6 +340,22 @@ int _cdecl main(int argc, char *argv[])
             bArgsOkay = FALSE;
             goto cleanup;
         }
+
+		printf("lpszLspPathAndFile = %hs\n", lpszLspPathAndFile);
+		printf("lpszLspPathAndFile32 = %hs\n", lpszLspPathAndFile32);
+
+#ifdef _WIN64
+		if (lpszLspPathAndFile && lpszLspPathAndFile32)
+		{
+			eCatalog = LspCatalogBoth;
+		}
+		else
+		{
+			fprintf( stderr, "\n\nError! Please specify both 64-bit and 32-bit paths of LSP!\n\n");
+            bArgsOkay = FALSE;
+            goto cleanup;
+		}
+#endif
 
         if ( TRUE == bInstallOverAll )
         {

--- a/Samples/Win7Samples/netds/winsock/lsp/install/lspadd.cpp
+++ b/Samples/Win7Samples/netds/winsock/lsp/install/lspadd.cpp
@@ -1322,7 +1322,7 @@ InstallProviderVista(
 #ifdef _WIN64
     if ( ( eCatalog == LspCatalog32Only ) || ( eCatalog == LspCatalog64Only ) )
     {
-        fprintf(stderr, "New install API always installs into both catalogs!\n");
+        fprintf(stderr, "New install API always installs into both catalogs - -d and -d32 flags are required!\n");
         goto cleanup;
     }
     else 
@@ -1365,7 +1365,7 @@ InstallProviderVista(
                 providerGuid,
                 lpszLspPathAndFile,
 #ifdef _WIN64
-                (lpszLspPathAndFile32[0] == '\0' ? lpszLspPathAndFile : lpszLspPathAndFile32),
+                lpszLspPathAndFile32,
 #endif
                 lpszLspName,
                 ( IfsProvider ? XP1_IFS_HANDLES : 0 ),
@@ -1422,7 +1422,7 @@ InstallProviderVista(
                 providerGuid,
                 lpszLspPathAndFile,
 #ifdef _WIN64
-                lpszLspPathAndFile,
+                lpszLspPathAndFile32,
 #endif
                 lpszLspName,
                 ( IfsProvider ? XP1_IFS_HANDLES : 0 ),


### PR DESCRIPTION
The LSP sample is great, but the installer is woeful on 64-bit. It just doesn't work, and was clearly not tested. I've made a few small fixes and I can install on Win10 x64 now.

- Make sure we always have a 32-bit and a 64-bit path. Loading a 64-bit DLL into a 32-bit process just doesn't work.
- Make sure we pass in the correct path in the correct spot.