### PR TITLE
Return value error.

### DIFF
--- a/Samples/CredentialProvider/cpp/helpers.cpp
+++ b/Samples/CredentialProvider/cpp/helpers.cpp
@@ -580,7 +580,7 @@ HRESULT KerbInteractiveUnlockLogonRepackNative(
                 }
                 else
                 {
-                    hr = GetLastError();
+                    hr = HRESULT_FROM_WIN32(GetLastError());
                 }
             }
         }

--- a/Samples/Win7Samples/security/credentialproviders/helpers/helpers.cpp
+++ b/Samples/Win7Samples/security/credentialproviders/helpers/helpers.cpp
@@ -574,7 +574,7 @@ HRESULT KerbInteractiveUnlockLogonRepackNative(
                 }
                 else
                 {
-                    hr = GetLastError();
+                    hr = HRESULT_FROM_WIN32(GetLastError());
                 }
             }
         }


### PR DESCRIPTION
If the CredUnPackAuthenticationBuffer fails, the return value should reflect that, but it must be an HRESULT.  We should convert a Windows error code to an HRESULT.