### PR TITLE
ExplorerDataProvider: Update shell folder to support IExplorerPaneVisibility

### DIFF
--- a/Samples/Win7Samples/winui/shell/shellextensibility/explorerdataprovider/ExplorerDataProvider.cpp
+++ b/Samples/Win7Samples/winui/shell/shellextensibility/explorerdataprovider/ExplorerDataProvider.cpp
@@ -1070,7 +1070,7 @@ HRESULT CFolderViewImplFolder::GetPaneState(
 {
     if (ep == EP_Ribbon)
     {
-        *peps = EPS_INITIALSTATE | EPS_DEFAULT_ON;
+        *peps = EPS_DEFAULT_ON;
     }
     else
     {

--- a/Samples/Win7Samples/winui/shell/shellextensibility/explorerdataprovider/ExplorerDataProvider.cpp
+++ b/Samples/Win7Samples/winui/shell/shellextensibility/explorerdataprovider/ExplorerDataProvider.cpp
@@ -48,7 +48,8 @@ typedef UNALIGNED FVITEMID *PFVITEMID;
 typedef const UNALIGNED FVITEMID *PCFVITEMID;
 
 class CFolderViewImplFolder : public IShellFolder2,
-                              public IPersistFolder2
+                              public IPersistFolder2,
+                              public IExplorerPaneVisibility
 {
 public:
     CFolderViewImplFolder(UINT nLevel);
@@ -89,6 +90,9 @@ public:
 
     // IPersistFolder2
     IFACEMETHODIMP GetCurFolder(PIDLIST_ABSOLUTE *ppidl);
+
+    // IExplorerPaneVisibility
+    IFACEMETHODIMP GetPaneState(REFEXPLORERPANE ep, EXPLORERPANESTATE* peps);
 
     // IDList constructor public for the enumerator object
     HRESULT CreateChildID(PCWSTR pszName, int nLevel, int nSize, int nSides, BOOL fIsFolder, PITEMID_CHILD *ppidl);
@@ -191,6 +195,7 @@ HRESULT CFolderViewImplFolder::QueryInterface(REFIID riid, void **ppv)
         QITABENT(CFolderViewImplFolder, IPersist),
         QITABENT(CFolderViewImplFolder, IPersistFolder),
         QITABENT(CFolderViewImplFolder, IPersistFolder2),
+        QITABENT(CFolderViewImplFolder, IExplorerPaneVisibility),
         { 0 },
     };
     return QISearch(this, qit, riid, ppv);
@@ -1056,6 +1061,24 @@ HRESULT CFolderViewImplFolder::GetCurFolder(PIDLIST_ABSOLUTE *ppidl)
     }
     return hr;
 }
+
+// IExplorerPaneVisibility methods
+HRESULT CFolderViewImplFolder::GetPaneState(
+    REFEXPLORERPANE ep,
+    EXPLORERPANESTATE* peps
+)
+{
+    if (ep == EP_Ribbon)
+    {
+        *peps = EPS_INITIALSTATE | EPS_DEFAULT_ON;
+    }
+    else
+    {
+        *peps = EPS_DONTCARE;
+    }
+    return S_OK;
+}
+
 
 // Item idlists passed to folder methods are guaranteed to have accessible memory as specified
 // by the cbSize in the itemid.  However they may be loaded from a persisted form (for example


### PR DESCRIPTION
Updates the Windows 7 ExplorerDataProvider sample to add support for IExplorerPaneVisibility. This is a workaround for an issue in Windows 11 23H2 where the breadcrumb bar does not update with the current folder while navigating folders in the shell namespace extension. 