### PR TITLE
Fix DragDropVisuals warnings that are treated as errors

### DIFF
--- a/Samples/Win7Samples/winui/shell/appplatform/DragDropVisuals/ShellHelpers.h
+++ b/Samples/Win7Samples/winui/shell/appplatform/DragDropVisuals/ShellHelpers.h
@@ -118,7 +118,7 @@ __inline HRESULT SetItemImageImageInStaticControl(HWND hwndStatic, IShellItem *p
         {
             RECT rc;
             GetWindowRect(hwndStatic, &rc);
-            const UINT dxdy = min(rc.right - rc.left, rc.bottom - rc.top);    // make it square
+            const LONG dxdy = min(rc.right - rc.left, rc.bottom - rc.top);    // make it square
             const SIZE size = { dxdy, dxdy };
 
             hr = psiif->GetImage(size, SIIGBF_RESIZETOFIT, &hbmp);


### PR DESCRIPTION
There are warnings reported in newer Visual Studio and treated as errors in compile-time:
![Before](https://github.com/microsoft/Windows-classic-samples/assets/55521781/f85d7c5f-b188-478a-95a7-e4de7a05c799)

After this fix, the build success:
![After](https://github.com/microsoft/Windows-classic-samples/assets/55521781/ae49827e-cf12-4dfa-ba7c-364441ec970f)
