### PR TITLE
Update TabWindow.cpp

### DIFF
--- a/Samples/Win7Samples/multimedia/DirectWrite/HelloWorld/TabWindow.cpp
+++ b/Samples/Win7Samples/multimedia/DirectWrite/HelloWorld/TabWindow.cpp
@@ -283,7 +283,7 @@ LRESULT CALLBACK TabWindow::WndProc(HWND hwnd, UINT message, WPARAM wParam, LPAR
         ::SetWindowLongPtrW(
             hwnd,
             GWLP_USERDATA,
-            PtrToUlong(pTabWindow));
+            reinterpret_cast<LONG_PTR>(pTabWindow));
 
         return 1;
     }


### PR DESCRIPTION
In project Windows-classic-samples/Samples/Win7Samples/multimedia/DirectWrite/HelloWorld, when processing message == WM_CREATE in TabWindow::WndProc(...), TabWindow fails to save its USERDATA with a ::SetWindowLongPtrW(hwnd, GWLP_USERDATA, PtrToUlong(pTabWindow)) call (file TabWindow.cpp, line 286), and consequently fails to initialize pTabWindow when processing later the WM_SIZE message. 

As the debugger reports an access violation exception in the _SCRT_STARTUP_WWINMAIN-branch routine, the error is hard to identify for beginner programmers.

Use a standard-compliant reinterpret_cast<LONG_PTR>(pTabWindow).