### PR TITLE
Update Presenter.cpp

### DIFF
--- a/Samples/Win7Samples/multimedia/mediafoundation/evrpresenter/Presenter.cpp
+++ b/Samples/Win7Samples/multimedia/mediafoundation/evrpresenter/Presenter.cpp
@@ -1409,7 +1409,8 @@ HRESULT EVRCustomPresenter::CreateOptimalVideoType(IMFMediaType* pProposedType, 
 
     // Helper object to manipulate the optimal type.
     VideoType mtOptimal;
-
+    mtOptimal.CreateEmptyType();
+    
     // Clone the proposed type.
     CHECK_HR(hr = mtOptimal.CopyFrom(pProposedType));
 


### PR DESCRIPTION
Correcting a bug in Presenter.cpp code: to create and initialize media type members, `mtOptimal.CreateEmptyType();` call must be added after `VideoType mtOptimal;` declaration (file Presenter.cpp, line 1411).