### PR TITLE
DirectWriteCustomFontSets: fix to run with up-to-date tools

### DIFF
--- a/Samples/DirectWriteCustomFontSets/README.md
+++ b/Samples/DirectWriteCustomFontSets/README.md
@@ -148,7 +148,8 @@ Studio 2017 Release Candidate or later.
 
 The project includes a subfolder, "Fonts", containing font files. These are 
 used for scenarios 1 and 2. This sample doesn't include any installer project. 
-In order for scenarios 1 and 2 to work, the Fonts folder and contents must be
+
+**NOTE:** In order for scenarios 1 and 2 to work, the Fonts folder and contents must be
 copied to the same folder as the app executable.
 
 

--- a/Samples/DirectWriteCustomFontSets/cpp/DWriteCustomFontSets.vcxproj
+++ b/Samples/DirectWriteCustomFontSets/cpp/DWriteCustomFontSets.vcxproj
@@ -23,32 +23,32 @@
     <ProjectGuid>{1E6FD614-369E-42FD-A361-AC5FACBA8EB0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>DWriteCustomFontSets</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15021.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -100,6 +100,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/Samples/DirectWriteCustomFontSets/cpp/FileHelper.cpp
+++ b/Samples/DirectWriteCustomFontSets/cpp/FileHelper.cpp
@@ -13,7 +13,7 @@
 #include "stdafx.h"
 #include "FileHelper.h"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 
 namespace DWriteCustomFontSets
@@ -46,7 +46,7 @@ namespace DWriteCustomFontSets
             return false;
         }
 
-        fs::path absPath = fs::system_complete(inFolderName);
+        fs::path absPath = fs::absolute(inFolderName);
         fs::file_status pathStatus = fs::status(absPath);
 
         // Confirm input path is a folder.


### PR DESCRIPTION
This sample was created circa 2015 -- 2017, using Visual Studio 2015 and targeting Win10 build 15021.  This change retargets for VS 2022.

Also, when boost filesystem::system_complete had experimental support in Visual Studio as std::filesystem:system_complete. That was not adopted into C++ 17. As a result, this project would no longer build in current tools. This change removes use of that experimental function, replacing it with std::filesystem::absolute() (functionally the same for purposes of this sample).

There's also a minor tweak to the README to highlight an important detail for running the sample.