### PR TITLE
msi\setup.exe: Fix a handle leak

### DIFF
--- a/Samples/Win7Samples/sysmgmt/msi/setup.exe/utils.cpp
+++ b/Samples/Win7Samples/sysmgmt/msi/setup.exe/utils.cpp
@@ -705,10 +705,12 @@ bool AcquireShutdownPrivilege()
     // cannot test return value of AdjustTokenPrivileges
     if (ERROR_SUCCESS != WIN::GetLastError())
     {
+        CloseHandle(hToken);
         FreeLibrary(hAdvapi32);
         return false;
     }
 
+    CloseHandle(hToken);
     FreeLibrary(hAdvapi32);
 
     return true;


### PR DESCRIPTION
The access token handle returned by `OpenProcessToken` should be closed when no longer needed.