### PR TITLE
[PasskeyManager] Update sample to address official API

### DIFF
--- a/Samples/PasskeyManager/.gitignore
+++ b/Samples/PasskeyManager/.gitignore
@@ -1,0 +1,1 @@
+cpp/include

--- a/Samples/PasskeyManager/README.md
+++ b/Samples/PasskeyManager/README.md
@@ -46,7 +46,7 @@ Windows 11 Insider Edition Beta Channel. Build Major Version = 22635 and Minor V
 #### Download Prerequisites
 
 * Download the [cbor-lite](https://bitbucket.org/isode/cbor-lite/src/master/include/) directory and copy it into the `include` directory of the sample.
-* Download the [webauthn](https://github.com/microsoft/webauthn/experimental) directory and copy it into the `include` directory of the sample.
+* Download the [webauthn](https://github.com/microsoft/webauthn) directory and copy it into the `include` directory of the sample.
 
 #### Fill in the plugin information.
 * Use guidgen.exe to generate a new GUID for the plugin.

--- a/Samples/PasskeyManager/cpp/MainPage.xaml.cpp
+++ b/Samples/PasskeyManager/cpp/MainPage.xaml.cpp
@@ -423,7 +423,7 @@ namespace winrt::PasskeyManager::implementation
         LogSuccess(L"All credentials deleted");
     }
 
-    void MainPage::UpdatePluginStateTextBlock(EXPERIMENTAL_PLUGIN_AUTHENTICATOR_STATE state)
+    void MainPage::UpdatePluginStateTextBlock(PLUGIN_AUTHENTICATOR_STATE state)
     {
         auto resources = Application::Current().Resources();
         auto successBrush = resources.Lookup(winrt::box_value(L"SystemFillColorSuccessBrush")).as<winrt::Microsoft::UI::Xaml::Media::SolidColorBrush>();

--- a/Samples/PasskeyManager/cpp/MainPage.xaml.cpp
+++ b/Samples/PasskeyManager/cpp/MainPage.xaml.cpp
@@ -423,7 +423,7 @@ namespace winrt::PasskeyManager::implementation
         LogSuccess(L"All credentials deleted");
     }
 
-    void MainPage::UpdatePluginStateTextBlock(PLUGIN_AUTHENTICATOR_STATE state)
+    void MainPage::UpdatePluginStateTextBlock(AUTHENTICATOR_STATE state)
     {
         auto resources = Application::Current().Resources();
         auto successBrush = resources.Lookup(winrt::box_value(L"SystemFillColorSuccessBrush")).as<winrt::Microsoft::UI::Xaml::Media::SolidColorBrush>();
@@ -432,16 +432,14 @@ namespace winrt::PasskeyManager::implementation
 
         switch (state)
         {
-        case PluginAuthenticatorState_Enabled:
+        case AuthenticatorState_Enabled:
             pluginStateRun().Text(L"Enabled");
             pluginStateRun().Foreground(successBrush);
             break;
-        case PluginAuthenticatorState_Disabled:
+        case AuthenticatorState_Disabled:
             pluginStateRun().Text(L"Disabled");
             pluginStateRun().Foreground(criticalBrush);
             break;
-        case PluginAuthenticatorState_Unknown:
-            [[fallthrough]];
         default:
             pluginStateRun().Text(L"Unknown");
             pluginStateRun().Foreground(cautionBrush);

--- a/Samples/PasskeyManager/cpp/MainPage.xaml.h
+++ b/Samples/PasskeyManager/cpp/MainPage.xaml.h
@@ -62,7 +62,7 @@ namespace winrt::PasskeyManager::implementation
             std::wstring result = L"WARNING: " + std::wstring(input.c_str()) + L": " + winrt::to_hstring(static_cast<int>(hr)).c_str() + L"\U000026A0";
             UpdatePasskeyOperationStatusText(winrt::hstring{ result });
         }
-        void UpdatePluginStateTextBlock(PLUGIN_AUTHENTICATOR_STATE state);
+        void UpdatePluginStateTextBlock(AUTHENTICATOR_STATE state);
         winrt::IAsyncAction SelectionChanged(IInspectable const& sender, Microsoft::UI::Xaml::Controls::SelectionChangedEventArgs const&);
         winrt::fire_and_forget UpdatePluginEnableState();
 

--- a/Samples/PasskeyManager/cpp/MainPage.xaml.h
+++ b/Samples/PasskeyManager/cpp/MainPage.xaml.h
@@ -62,7 +62,7 @@ namespace winrt::PasskeyManager::implementation
             std::wstring result = L"WARNING: " + std::wstring(input.c_str()) + L": " + winrt::to_hstring(static_cast<int>(hr)).c_str() + L"\U000026A0";
             UpdatePasskeyOperationStatusText(winrt::hstring{ result });
         }
-        void UpdatePluginStateTextBlock(EXPERIMENTAL_PLUGIN_AUTHENTICATOR_STATE state);
+        void UpdatePluginStateTextBlock(PLUGIN_AUTHENTICATOR_STATE state);
         winrt::IAsyncAction SelectionChanged(IInspectable const& sender, Microsoft::UI::Xaml::Controls::SelectionChangedEventArgs const&);
         winrt::fire_and_forget UpdatePluginEnableState();
 

--- a/Samples/PasskeyManager/cpp/PluginAuthenticator/PluginAuthenticatorImpl.cpp
+++ b/Samples/PasskeyManager/cpp/PluginAuthenticator/PluginAuthenticatorImpl.cpp
@@ -113,7 +113,7 @@ namespace winrt::PasskeyManager::implementation
         return S_OK;
     }
 
-    HRESULT PerformUv(
+    HRESULT PerformUserVerification(
         winrt::com_ptr<winrt::PasskeyManager::implementation::App>& curApp,
         HWND hWnd,
         wil::shared_hmodule webauthnDll,
@@ -413,7 +413,7 @@ namespace winrt::PasskeyManager::implementation
     * This function is invoked by the platform to request the plugin to handle a make credential operation.
     * Refer: pluginauthenticator.h/pluginauthenticator.idl
     */
-    HRESULT STDMETHODCALLTYPE ContosoPlugin::PluginMakeCredential(
+    HRESULT STDMETHODCALLTYPE ContosoPlugin::MakeCredential(
         /* [in] */ __RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginMakeCredentialRequest,
         /* [out] */ __RPC__deref_out_opt PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept
     {
@@ -463,7 +463,7 @@ namespace winrt::PasskeyManager::implementation
                 curApp->m_pluginOperationStatus.requestSignatureVerificationStatus = requestSignResult;
             }
 
-            THROW_IF_FAILED(PerformUv(curApp,
+            THROW_IF_FAILED(PerformUserVerification(curApp,
                 pPluginMakeCredentialRequest->hWnd,
                 webauthnDll,
                 pPluginMakeCredentialRequest->transactionId,
@@ -610,7 +610,7 @@ namespace winrt::PasskeyManager::implementation
     * This function is invoked by the platform to request the plugin to handle a get assertion operation.
     * Refer: pluginauthenticator.h/pluginauthenticator.idl
     */
-    HRESULT STDMETHODCALLTYPE ContosoPlugin::PluginGetAssertion(
+    HRESULT STDMETHODCALLTYPE ContosoPlugin::GetAssertion(
         /* [in] */ __RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginGetAssertionRequest,
         /* [out] */ __RPC__deref_out_opt PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept
     {
@@ -718,7 +718,7 @@ namespace winrt::PasskeyManager::implementation
                 curApp->m_pluginOperationStatus.requestSignatureVerificationStatus = requestSignResult;
             }
 
-            THROW_IF_FAILED(PerformUv(curApp,
+            THROW_IF_FAILED(PerformUserVerification(curApp,
                 pPluginGetAssertionRequest->hWnd,
                 webauthnDll,
                 pPluginGetAssertionRequest->transactionId,
@@ -934,8 +934,8 @@ namespace winrt::PasskeyManager::implementation
     /*
     * This function is invoked by the platform to request the plugin to cancel an ongoing operation.
     */
-    HRESULT STDMETHODCALLTYPE ContosoPlugin::PluginCancelOperation(
-        /* [out] */ __RPC__in PCWEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST)
+    HRESULT STDMETHODCALLTYPE ContosoPlugin::CancelOperation(
+        /* [in] */ __RPC__in PCWEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST)
     {
         SetEvent(App::s_pluginOpRequestRecievedEvent.get());
         com_ptr<App> curApp = winrt::Microsoft::UI::Xaml::Application::Current().as<App>();

--- a/Samples/PasskeyManager/cpp/PluginAuthenticator/PluginAuthenticatorImpl.cpp
+++ b/Samples/PasskeyManager/cpp/PluginAuthenticator/PluginAuthenticatorImpl.cpp
@@ -946,6 +946,13 @@ namespace winrt::PasskeyManager::implementation
         return S_OK;
     }
 
+    HRESULT STDMETHODCALLTYPE ContosoPlugin::GetLockStatus(
+        /* [out] */ __RPC__out PLUGIN_LOCK_STATUS* lockStatus) noexcept
+    {
+        *lockStatus = PluginUnlocked;
+        return S_OK;
+    }
+
     /*
     * This is a sample implementation of a factory method that creates an instance of the Class that implements the IPluginAuthenticator interface.
     * Refer: pluginauthenticator.h/pluginauthenticator.idl for the interface definition.

--- a/Samples/PasskeyManager/cpp/PluginAuthenticator/PluginAuthenticatorImpl.h
+++ b/Samples/PasskeyManager/cpp/PluginAuthenticator/PluginAuthenticatorImpl.h
@@ -14,11 +14,11 @@ static constexpr wchar_t contosoplugin_key_domain[] = L"contoso/";
 
 namespace winrt::PasskeyManager::implementation
 {
-    struct ContosoPlugin : winrt::implements<ContosoPlugin, EXPERIMENTAL_IPluginAuthenticator>
+    struct ContosoPlugin : winrt::implements<ContosoPlugin, IPluginAuthenticator>
     {
-        HRESULT __stdcall EXPERIMENTAL_PluginMakeCredential(__RPC__in EXPERIMENTAL_PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginMakeCredentialRequest, __RPC__deref_out_opt EXPERIMENTAL_PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept;
-        HRESULT __stdcall EXPERIMENTAL_PluginGetAssertion(__RPC__in EXPERIMENTAL_PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginGetAssertionRequest, __RPC__deref_out_opt EXPERIMENTAL_PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept;
-        HRESULT __stdcall EXPERIMENTAL_PluginCancelOperation(__RPC__in EXPERIMENTAL_PCWEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST pCancelRequest);
+        HRESULT __stdcall PluginMakeCredential(__RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginMakeCredentialRequest, __RPC__deref_out_opt PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept;
+        HRESULT __stdcall PluginGetAssertion(__RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginGetAssertionRequest, __RPC__deref_out_opt PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept;
+        HRESULT __stdcall PluginCancelOperation(__RPC__in PCWEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST pCancelRequest);
     };
 
     struct ContosoPluginFactory : implements<ContosoPluginFactory, IClassFactory>

--- a/Samples/PasskeyManager/cpp/PluginAuthenticator/PluginAuthenticatorImpl.h
+++ b/Samples/PasskeyManager/cpp/PluginAuthenticator/PluginAuthenticatorImpl.h
@@ -19,6 +19,7 @@ namespace winrt::PasskeyManager::implementation
         HRESULT __stdcall MakeCredential(__RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginMakeCredentialRequest, __RPC__deref_out_opt PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept;
         HRESULT __stdcall GetAssertion(__RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginGetAssertionRequest, __RPC__deref_out_opt PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept;
         HRESULT __stdcall CancelOperation(__RPC__in PCWEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST pCancelRequest);
+        HRESULT __stdcall GetLockStatus(__RPC__out PLUGIN_LOCK_STATUS* lockStatus) noexcept;
     };
 
     struct ContosoPluginFactory : implements<ContosoPluginFactory, IClassFactory>

--- a/Samples/PasskeyManager/cpp/PluginAuthenticator/PluginAuthenticatorImpl.h
+++ b/Samples/PasskeyManager/cpp/PluginAuthenticator/PluginAuthenticatorImpl.h
@@ -16,9 +16,9 @@ namespace winrt::PasskeyManager::implementation
 {
     struct ContosoPlugin : winrt::implements<ContosoPlugin, IPluginAuthenticator>
     {
-        HRESULT __stdcall PluginMakeCredential(__RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginMakeCredentialRequest, __RPC__deref_out_opt PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept;
-        HRESULT __stdcall PluginGetAssertion(__RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginGetAssertionRequest, __RPC__deref_out_opt PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept;
-        HRESULT __stdcall PluginCancelOperation(__RPC__in PCWEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST pCancelRequest);
+        HRESULT __stdcall MakeCredential(__RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginMakeCredentialRequest, __RPC__deref_out_opt PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept;
+        HRESULT __stdcall GetAssertion(__RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginGetAssertionRequest, __RPC__deref_out_opt PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept;
+        HRESULT __stdcall CancelOperation(__RPC__in PCWEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST pCancelRequest);
     };
 
     struct ContosoPluginFactory : implements<ContosoPluginFactory, IClassFactory>

--- a/Samples/PasskeyManager/cpp/PluginAuthenticator/PluginAuthenticatorImpl.h
+++ b/Samples/PasskeyManager/cpp/PluginAuthenticator/PluginAuthenticatorImpl.h
@@ -16,8 +16,8 @@ namespace winrt::PasskeyManager::implementation
 {
     struct ContosoPlugin : winrt::implements<ContosoPlugin, IPluginAuthenticator>
     {
-        HRESULT __stdcall MakeCredential(__RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginMakeCredentialRequest, __RPC__deref_out_opt PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept;
-        HRESULT __stdcall GetAssertion(__RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginGetAssertionRequest, __RPC__deref_out_opt PWEBAUTHN_PLUGIN_OPERATION_RESPONSE* response) noexcept;
+        HRESULT __stdcall MakeCredential(__RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginMakeCredentialRequest, __RPC__out PWEBAUTHN_PLUGIN_OPERATION_RESPONSE response) noexcept;
+        HRESULT __stdcall GetAssertion(__RPC__in PCWEBAUTHN_PLUGIN_OPERATION_REQUEST pPluginGetAssertionRequest, __RPC__out PWEBAUTHN_PLUGIN_OPERATION_RESPONSE response) noexcept;
         HRESULT __stdcall CancelOperation(__RPC__in PCWEBAUTHN_PLUGIN_CANCEL_OPERATION_REQUEST pCancelRequest);
         HRESULT __stdcall GetLockStatus(__RPC__out PLUGIN_LOCK_STATUS* lockStatus) noexcept;
     };

--- a/Samples/PasskeyManager/cpp/PluginManagement/PluginCredentialManager.cpp
+++ b/Samples/PasskeyManager/cpp/PluginManagement/PluginCredentialManager.cpp
@@ -25,14 +25,14 @@ namespace winrt::PasskeyManager::implementation
     HRESULT PluginCredentialManager::AddAllPluginCredentials()
     {
         // Get the function pointer of WebAuthNPluginAuthenticatorAddCredentials
-        auto webAuthNPluginAuthenticatorAddCredentials = GetProcAddressByFunctionDeclaration(m_webAuthnDll.get(), EXPERIMENTAL_WebAuthNPluginAuthenticatorAddCredentials);
+        auto webAuthNPluginAuthenticatorAddCredentials = GetProcAddressByFunctionDeclaration(m_webAuthnDll.get(), WebAuthNPluginAuthenticatorAddCredentials);
         RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginAuthenticatorAddCredentials);
 
         std::vector<unique_plugin_credential_details> credentialDetailList{};
         for (auto& iter : m_pluginLocalCredentialMetadataMap)
         {
             auto& savedCred = iter.second;
-            unique_plugin_credential_details pluginCred (new EXPERIMENTAL_WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS());
+            unique_plugin_credential_details pluginCred (new WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS());
             pluginCred->pwszRpId = _wcsdup(savedCred->pRpInformation->pwszId);
             pluginCred->pwszRpName = _wcsdup(savedCred->pRpInformation->pwszName);
             pluginCred->pwszUserName = _wcsdup(savedCred->pUserInformation->pwszName);
@@ -47,9 +47,9 @@ namespace winrt::PasskeyManager::implementation
         }
 
         RETURN_HR_IF(E_FAIL, credentialDetailList.empty());
-        EXPERIMENTAL_WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS_LIST pluginCredentialList;
+        WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS_LIST pluginCredentialList;
         pluginCredentialList.cCredentialDetails = static_cast<DWORD>(credentialDetailList.size());
-        auto credentialDetailPtrList = std::vector<EXPERIMENTAL_PWEBAUTHN_PLUGIN_CREDENTIAL_DETAILS>{};
+        auto credentialDetailPtrList = std::vector<PWEBAUTHN_PLUGIN_CREDENTIAL_DETAILS>{};
         for (auto& credential : credentialDetailList)
         {
             credentialDetailPtrList.push_back(credential.get());
@@ -66,7 +66,7 @@ namespace winrt::PasskeyManager::implementation
         RETURN_HR_IF(E_FAIL, credentialIdList.empty());
 
         // Get the function pointer of WebAuthNPluginAuthenticatorAddCredentials
-        auto webAuthNPluginAuthenticatorAddCredentials = GetProcAddressByFunctionDeclaration(m_webAuthnDll.get(), EXPERIMENTAL_WebAuthNPluginAuthenticatorAddCredentials);
+        auto webAuthNPluginAuthenticatorAddCredentials = GetProcAddressByFunctionDeclaration(m_webAuthnDll.get(), WebAuthNPluginAuthenticatorAddCredentials);
         RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginAuthenticatorAddCredentials);
 
         std::vector<unique_plugin_credential_details> credentialDetailList{};
@@ -77,7 +77,7 @@ namespace winrt::PasskeyManager::implementation
             if (iter != m_pluginLocalCredentialMetadataMap.end())
             {
                 auto& savedCred = iter->second;
-                unique_plugin_credential_details pluginCred (new EXPERIMENTAL_WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS ());
+                unique_plugin_credential_details pluginCred (new WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS ());
                 pluginCred->pwszRpId = _wcsdup(savedCred->pRpInformation->pwszId);
                 pluginCred->pwszRpName = _wcsdup(savedCred->pRpInformation->pwszName);
                 pluginCred->pwszUserName = _wcsdup(savedCred->pUserInformation->pwszName);
@@ -94,9 +94,9 @@ namespace winrt::PasskeyManager::implementation
 
         if (!credentialDetailList.empty())
         {
-            EXPERIMENTAL_WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS_LIST pluginCredentialList;
+            WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS_LIST pluginCredentialList;
             pluginCredentialList.cCredentialDetails = static_cast<DWORD>(credentialDetailList.size());
-            std::vector<EXPERIMENTAL_PWEBAUTHN_PLUGIN_CREDENTIAL_DETAILS> credentialDetailPtrList{};
+            std::vector<PWEBAUTHN_PLUGIN_CREDENTIAL_DETAILS> credentialDetailPtrList{};
             for (auto& credential : credentialDetailList)
             {
                 credentialDetailPtrList.push_back(credential.get());
@@ -114,7 +114,7 @@ namespace winrt::PasskeyManager::implementation
         // Get the function pointer of WebAuthNPluginAuthenticatorAddCredentials
         auto webAuthNPluginAuthenticatorRemoveAllCredentials = GetProcAddressByFunctionDeclaration(
             m_webAuthnDll.get(),
-            EXPERIMENTAL_WebAuthNPluginAuthenticatorRemoveAllCredentials);
+            WebAuthNPluginAuthenticatorRemoveAllCredentials);
         RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginAuthenticatorRemoveAllCredentials);
         RETURN_HR(webAuthNPluginAuthenticatorRemoveAllCredentials(c_pluginClsid));
     }
@@ -126,7 +126,7 @@ namespace winrt::PasskeyManager::implementation
         // Get the function pointer of WebAuthNPluginAddAuthenticator
         auto webAuthNPluginRemoveCredential = GetProcAddressByFunctionDeclaration(
                 m_webAuthnDll.get(),
-                EXPERIMENTAL_WebAuthNPluginAuthenticatorRemoveCredentials);
+                WebAuthNPluginAuthenticatorRemoveCredentials);
         RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginRemoveCredential);
 
         std::vector<unique_plugin_credential_details> credentialDetailList{};
@@ -145,9 +145,9 @@ namespace winrt::PasskeyManager::implementation
 
         if (!credentialDetailList.empty())
         {
-            EXPERIMENTAL_WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS_LIST pluginCredentialList;
+            WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS_LIST pluginCredentialList;
             pluginCredentialList.cCredentialDetails = static_cast<DWORD>(credentialDetailList.size());
-            std::vector<EXPERIMENTAL_PWEBAUTHN_PLUGIN_CREDENTIAL_DETAILS> credentialDetailPtrList{};
+            std::vector<PWEBAUTHN_PLUGIN_CREDENTIAL_DETAILS> credentialDetailPtrList{};
             for (auto& credential : credentialDetailList)
             {
                 credentialDetailPtrList.push_back(credential.get());
@@ -177,22 +177,22 @@ namespace winrt::PasskeyManager::implementation
         std::lock_guard<std::mutex> lock(m_pluginCachedCredentialsOperationMutex);
         m_cachedCredentialsLoaded = false;
         m_pluginCachedCredentialMetadataMap.clear();
-        // Get the function pointer of EXPERIMENTAL_WebAuthNPluginAuthenticatorGetAllCredentials
+        // Get the function pointer of WebAuthNPluginAuthenticatorGetAllCredentials
         auto webAuthNPluginAuthenticatorGetAllCredentials = GetProcAddressByFunctionDeclaration(m_webAuthnDll.get(),
-            EXPERIMENTAL_WebAuthNPluginAuthenticatorGetAllCredentials);
+            WebAuthNPluginAuthenticatorGetAllCredentials);
         RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginAuthenticatorGetAllCredentials);
 
-        EXPERIMENTAL_PWEBAUTHN_PLUGIN_CREDENTIAL_DETAILS_LIST localCredentialDetailsList = nullptr;
+        PWEBAUTHN_PLUGIN_CREDENTIAL_DETAILS_LIST localCredentialDetailsList = nullptr;
         HRESULT hr = webAuthNPluginAuthenticatorGetAllCredentials(c_pluginClsid, &localCredentialDetailsList);
         RETURN_HR_IF_EXPECTED(S_OK, hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
 
         for (DWORD i = 0; i < localCredentialDetailsList->cCredentialDetails; i++)
         {
-            EXPERIMENTAL_PWEBAUTHN_PLUGIN_CREDENTIAL_DETAILS credentialDetailsPtr = localCredentialDetailsList->pCredentialDetails[i];
+            PWEBAUTHN_PLUGIN_CREDENTIAL_DETAILS credentialDetailsPtr = localCredentialDetailsList->pCredentialDetails[i];
             std::vector<UINT8> credentialId(credentialDetailsPtr->pbCredentialId, credentialDetailsPtr->pbCredentialId + credentialDetailsPtr->cbCredentialId);
 
             // Create a copy of the credential details
-            unique_plugin_credential_details credentialDetailsCopy(new EXPERIMENTAL_WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS());
+            unique_plugin_credential_details credentialDetailsCopy(new WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS());
             credentialDetailsCopy->cbCredentialId = credentialDetailsPtr->cbCredentialId;
             credentialDetailsCopy->pbCredentialId = wil::make_unique_nothrow<BYTE[]>(credentialDetailsPtr->cbCredentialId).release();
             if (credentialDetailsCopy->pbCredentialId == nullptr || credentialDetailsPtr->cbCredentialId == 0 || credentialDetailsPtr->pbCredentialId == nullptr)

--- a/Samples/PasskeyManager/cpp/PluginManagement/PluginCredentialManager.cpp
+++ b/Samples/PasskeyManager/cpp/PluginManagement/PluginCredentialManager.cpp
@@ -124,10 +124,10 @@ namespace winrt::PasskeyManager::implementation
         RETURN_HR_IF(E_FAIL, credentialIdList.empty());
 
         // Get the function pointer of WebAuthNPluginAddAuthenticator
-        auto webAuthNPluginRemoveCredential = GetProcAddressByFunctionDeclaration(
+        auto webAuthNPluginRemoveCredentials = GetProcAddressByFunctionDeclaration(
                 m_webAuthnDll.get(),
                 WebAuthNPluginAuthenticatorRemoveCredentials);
-        RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginRemoveCredential);
+        RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginRemoveCredentials);
 
         std::vector<unique_plugin_credential_details> credentialDetailList{};
 

--- a/Samples/PasskeyManager/cpp/PluginManagement/PluginCredentialManager.cpp
+++ b/Samples/PasskeyManager/cpp/PluginManagement/PluginCredentialManager.cpp
@@ -39,10 +39,10 @@ namespace winrt::PasskeyManager::implementation
             pluginCred->pwszUserDisplayName = _wcsdup(savedCred->pUserInformation->pwszDisplayName);
             pluginCred->cbUserId = savedCred->pUserInformation->cbId;
             pluginCred->pbUserId = wil::make_unique_nothrow<BYTE[]>(pluginCred->cbUserId).release();
-            memcpy_s(pluginCred->pbUserId, pluginCred->cbUserId, savedCred->pUserInformation->pbId, savedCred->pUserInformation->cbId);
+            memcpy_s(const_cast<BYTE*>(pluginCred->pbUserId), pluginCred->cbUserId, savedCred->pUserInformation->pbId, savedCred->pUserInformation->cbId);
             pluginCred->cbCredentialId = savedCred->cbCredentialID;
             pluginCred->pbCredentialId = wil::make_unique_nothrow<BYTE[]>(pluginCred->cbCredentialId).release();
-            memcpy_s(pluginCred->pbCredentialId, pluginCred->cbCredentialId, savedCred->pbCredentialID, savedCred->cbCredentialID);
+            memcpy_s(const_cast<BYTE*>(pluginCred->pbCredentialId), pluginCred->cbCredentialId, savedCred->pbCredentialID, savedCred->cbCredentialID);
             credentialDetailList.push_back(std::move(pluginCred));
         }
 
@@ -84,10 +84,10 @@ namespace winrt::PasskeyManager::implementation
                 pluginCred->pwszUserDisplayName = _wcsdup(savedCred->pUserInformation->pwszDisplayName);
                 pluginCred->cbUserId = savedCred->pUserInformation->cbId;
                 pluginCred->pbUserId = wil::make_unique_nothrow<BYTE[]>(pluginCred->cbUserId).release();
-                memcpy_s(pluginCred->pbUserId, pluginCred->cbUserId, savedCred->pUserInformation->pbId, savedCred->pUserInformation->cbId);
+                memcpy_s(const_cast<BYTE*>(pluginCred->pbUserId), pluginCred->cbUserId, savedCred->pUserInformation->pbId, savedCred->pUserInformation->cbId);
                 pluginCred->cbCredentialId = savedCred->cbCredentialID;
                 pluginCred->pbCredentialId = wil::make_unique_nothrow<BYTE[]>(pluginCred->cbCredentialId).release();
-                memcpy_s(pluginCred->pbCredentialId, pluginCred->cbCredentialId, savedCred->pbCredentialID, savedCred->cbCredentialID);
+                memcpy_s(const_cast<BYTE*>(pluginCred->pbCredentialId), pluginCred->cbCredentialId, savedCred->pbCredentialID, savedCred->cbCredentialID);
                 credentialDetailList.push_back(std::move(pluginCred));
             }
         }
@@ -204,7 +204,7 @@ namespace winrt::PasskeyManager::implementation
             {
                 continue;
             }
-            memcpy_s(credentialDetailsCopy->pbCredentialId,
+            memcpy_s(const_cast<BYTE*>(credentialDetailsCopy->pbCredentialId),
                 credentialDetailsCopy->cbCredentialId,
                 credentialDetailsPtr->pbCredentialId,
                 credentialDetailsPtr->cbCredentialId);
@@ -217,7 +217,7 @@ namespace winrt::PasskeyManager::implementation
                 continue;
             }
             memcpy_s(
-                credentialDetailsCopy->pbUserId,
+                const_cast<BYTE*>(credentialDetailsCopy->pbUserId),
                 credentialDetailsCopy->cbUserId,
                 credentialDetailsPtr->pbUserId,
                 credentialDetailsPtr->cbUserId);

--- a/Samples/PasskeyManager/cpp/PluginManagement/PluginCredentialManager.cpp
+++ b/Samples/PasskeyManager/cpp/PluginManagement/PluginCredentialManager.cpp
@@ -116,7 +116,12 @@ namespace winrt::PasskeyManager::implementation
             m_webAuthnDll.get(),
             WebAuthNPluginAuthenticatorRemoveAllCredentials);
         RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginAuthenticatorRemoveAllCredentials);
-        RETURN_HR(webAuthNPluginAuthenticatorRemoveAllCredentials(c_pluginClsid));
+
+        // Convert c_pluginClsid to a CLSID
+        CLSID CLSID_PluginAuthenticator;
+        RETURN_IF_FAILED(CLSIDFromString(c_pluginClsid, &CLSID_PluginAuthenticator));
+
+        RETURN_HR(webAuthNPluginAuthenticatorRemoveAllCredentials(CLSID_PluginAuthenticator));
     }
 
     HRESULT PluginCredentialManager::DeletePluginCredentialById(std::vector<std::vector<UINT8>> const& credentialIdList, bool deleteEverywhere)

--- a/Samples/PasskeyManager/cpp/PluginManagement/PluginCredentialManager.h
+++ b/Samples/PasskeyManager/cpp/PluginManagement/PluginCredentialManager.h
@@ -25,7 +25,7 @@ constexpr wchar_t c_pluginLocalAppDataDBDir[] = L"CredentialsDB";
 constexpr wchar_t c_credentialsFileName[] = L"credentials.dat";
 
 struct PluginCredentialDetailsDeleter {
-    void operator()(EXPERIMENTAL_PWEBAUTHN_PLUGIN_CREDENTIAL_DETAILS p) {
+    void operator()(PWEBAUTHN_PLUGIN_CREDENTIAL_DETAILS p) {
         delete[](p->pbCredentialId);
         free(p->pwszRpId);
         free(p->pwszRpName);
@@ -34,7 +34,7 @@ struct PluginCredentialDetailsDeleter {
         free(p->pwszUserDisplayName);
     }
 };
-using unique_plugin_credential_details = std::unique_ptr<EXPERIMENTAL_WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS, PluginCredentialDetailsDeleter>;
+using unique_plugin_credential_details = std::unique_ptr<WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS, PluginCredentialDetailsDeleter>;
 
 struct CredentialDetailsDeleter {
     void operator()(PWEBAUTHN_CREDENTIAL_DETAILS p) {

--- a/Samples/PasskeyManager/cpp/PluginManagement/PluginCredentialManager.h
+++ b/Samples/PasskeyManager/cpp/PluginManagement/PluginCredentialManager.h
@@ -27,11 +27,11 @@ constexpr wchar_t c_credentialsFileName[] = L"credentials.dat";
 struct PluginCredentialDetailsDeleter {
     void operator()(PWEBAUTHN_PLUGIN_CREDENTIAL_DETAILS p) {
         delete[](p->pbCredentialId);
-        free(p->pwszRpId);
-        free(p->pwszRpName);
+        delete[](p->pwszRpId);
+        delete[](p->pwszRpName);
         delete[](p->pbUserId);
-        free(p->pwszUserName);
-        free(p->pwszUserDisplayName);
+        delete[](p->pwszUserName);
+        delete[](p->pwszUserDisplayName);
     }
 };
 using unique_plugin_credential_details = std::unique_ptr<WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS, PluginCredentialDetailsDeleter>;

--- a/Samples/PasskeyManager/cpp/PluginManagement/PluginRegistrationManager.cpp
+++ b/Samples/PasskeyManager/cpp/PluginManagement/PluginRegistrationManager.cpp
@@ -55,12 +55,12 @@ namespace winrt::PasskeyManager::implementation {
         std::vector<BYTE> authenticatorInfo = hexStringToBytes(fullAuthenticatorInfoStr);
 
         // Validate that c_pluginClsid is a valid CLSID
-        CLSID CLSID_ContosoPluginAuthenticator;
-        RETURN_IF_FAILED(CLSIDFromString(c_pluginClsid, &CLSID_ContosoPluginAuthenticator));
+        CLSID CLSID_PluginAuthenticator;
+        RETURN_IF_FAILED(CLSIDFromString(c_pluginClsid, &CLSID_PluginAuthenticator));
 
         WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_OPTIONS addOptions{
             c_pluginName,
-            CLSID_ContosoPluginAuthenticator,
+            CLSID_PluginAuthenticator,
         };
         addOptions.pwszPluginRpId = c_pluginRpId;
         addOptions.pbAuthenticatorInfo = authenticatorInfo.data();
@@ -100,7 +100,11 @@ namespace winrt::PasskeyManager::implementation {
             WebAuthNPluginRemoveAuthenticator);
         RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginRemoveAuthenticator);
 
-        RETURN_HR(webAuthNPluginRemoveAuthenticator(c_pluginClsid));
+        // Convert c_pluginClsid to a CLSID
+        CLSID CLSID_PluginAuthenticator;
+        RETURN_IF_FAILED(CLSIDFromString(c_pluginClsid, &CLSID_PluginAuthenticator));
+
+        RETURN_HR(webAuthNPluginRemoveAuthenticator(CLSID_PluginAuthenticator));
     }
 
     HRESULT PluginRegistrationManager::RefreshPluginState()
@@ -115,9 +119,13 @@ namespace winrt::PasskeyManager::implementation {
             WebAuthNPluginGetAuthenticatorState);
         RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginGetAuthenticatorState);
 
+        // Convert c_pluginClsid to a CLSID
+        CLSID CLSID_PluginAuthenticator;
+        RETURN_IF_FAILED(CLSIDFromString(c_pluginClsid, &CLSID_PluginAuthenticator));
+
         // Get the plugin state
         AUTHENTICATOR_STATE localPluginState;
-        RETURN_IF_FAILED(webAuthNPluginGetAuthenticatorState(c_pluginClsid, &localPluginState));
+        RETURN_IF_FAILED(webAuthNPluginGetAuthenticatorState(CLSID_PluginAuthenticator, &localPluginState));
 
         // If the WebAuthNPluginGetAuthenticatorState function succeeded, that indicates the plugin is registered and localPluginState is the valid plugin state
         m_pluginRegistered = true;

--- a/Samples/PasskeyManager/cpp/PluginManagement/PluginRegistrationManager.cpp
+++ b/Samples/PasskeyManager/cpp/PluginManagement/PluginRegistrationManager.cpp
@@ -58,10 +58,11 @@ namespace winrt::PasskeyManager::implementation {
         CLSID CLSID_ContosoPluginAuthenticator;
         RETURN_IF_FAILED(CLSIDFromString(c_pluginClsid, &CLSID_ContosoPluginAuthenticator));
 
-        WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_OPTIONS addOptions{};
-        addOptions.pwszAuthenticatorName = c_pluginName;
+        WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_OPTIONS addOptions{
+            c_pluginName,
+            CLSID_ContosoPluginAuthenticator,
+        };
         addOptions.pwszPluginRpId = c_pluginRpId;
-        addOptions.pwszPluginClsId = c_pluginClsid;
         addOptions.pbAuthenticatorInfo = authenticatorInfo.data();
         addOptions.cbAuthenticatorInfo = static_cast<DWORD>(authenticatorInfo.size());
 

--- a/Samples/PasskeyManager/cpp/PluginManagement/PluginRegistrationManager.cpp
+++ b/Samples/PasskeyManager/cpp/PluginManagement/PluginRegistrationManager.cpp
@@ -7,7 +7,7 @@ namespace winrt::PasskeyManager::implementation {
     PluginRegistrationManager::PluginRegistrationManager() :
         m_pluginRegistered(false),
         m_initialized(false),
-        m_pluginState(PLUGIN_AUTHENTICATOR_STATE::PluginAuthenticatorState_Unknown)
+        m_pluginState(AUTHENTICATOR_STATE::AuthenticatorState_Disabled)
     {
         Initialize();
         m_webAuthnDll.reset(LoadLibraryExW(L"webauthn.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
@@ -106,16 +106,16 @@ namespace winrt::PasskeyManager::implementation {
     {
         // Reset the plugin state and registration status
         m_pluginRegistered = false;
-        m_pluginState = PLUGIN_AUTHENTICATOR_STATE::PluginAuthenticatorState_Unknown;
+        m_pluginState = AUTHENTICATOR_STATE::AuthenticatorState_Disabled;
 
-        // Get handle to WebAuthNPluginGetAuthenticatorState which takes in a GUID and returns PLUGIN_AUTHENTICATOR_STATE
+        // Get handle to WebAuthNPluginGetAuthenticatorState which takes in a GUID and returns AUTHENTICATOR_STATE
         auto webAuthNPluginGetAuthenticatorState = GetProcAddressByFunctionDeclaration(
             m_webAuthnDll.get(),
             WebAuthNPluginGetAuthenticatorState);
         RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginGetAuthenticatorState);
 
         // Get the plugin state
-        PLUGIN_AUTHENTICATOR_STATE localPluginState;
+        AUTHENTICATOR_STATE localPluginState;
         RETURN_IF_FAILED(webAuthNPluginGetAuthenticatorState(c_pluginClsid, &localPluginState));
 
         // If the WebAuthNPluginGetAuthenticatorState function succeeded, that indicates the plugin is registered and localPluginState is the valid plugin state

--- a/Samples/PasskeyManager/cpp/PluginManagement/PluginRegistrationManager.cpp
+++ b/Samples/PasskeyManager/cpp/PluginManagement/PluginRegistrationManager.cpp
@@ -7,7 +7,7 @@ namespace winrt::PasskeyManager::implementation {
     PluginRegistrationManager::PluginRegistrationManager() :
         m_pluginRegistered(false),
         m_initialized(false),
-        m_pluginState(EXPERIMENTAL_PLUGIN_AUTHENTICATOR_STATE::PluginAuthenticatorState_Unknown)
+        m_pluginState(PLUGIN_AUTHENTICATOR_STATE::PluginAuthenticatorState_Unknown)
     {
         Initialize();
         m_webAuthnDll.reset(LoadLibraryExW(L"webauthn.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
@@ -29,7 +29,7 @@ namespace winrt::PasskeyManager::implementation {
         // Get the function pointer of WebAuthNPluginAddAuthenticator
         auto webAuthNPluginAddAuthenticator = GetProcAddressByFunctionDeclaration(
             m_webAuthnDll.get(),
-            EXPERIMENTAL_WebAuthNPluginAddAuthenticator);
+            WebAuthNPluginAddAuthenticator);
         RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginAddAuthenticator);
 
         /*
@@ -58,14 +58,14 @@ namespace winrt::PasskeyManager::implementation {
         CLSID CLSID_ContosoPluginAuthenticator;
         RETURN_IF_FAILED(CLSIDFromString(c_pluginClsid, &CLSID_ContosoPluginAuthenticator));
 
-        EXPERIMENTAL_WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_OPTIONS addOptions{};
+        WEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_OPTIONS addOptions{};
         addOptions.pwszAuthenticatorName = c_pluginName;
         addOptions.pwszPluginRpId = c_pluginRpId;
         addOptions.pwszPluginClsId = c_pluginClsid;
         addOptions.pbAuthenticatorInfo = authenticatorInfo.data();
         addOptions.cbAuthenticatorInfo = static_cast<DWORD>(authenticatorInfo.size());
 
-        EXPERIMENTAL_PWEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_RESPONSE addResponse;
+        PWEBAUTHN_PLUGIN_ADD_AUTHENTICATOR_RESPONSE addResponse;
         RETURN_IF_FAILED(webAuthNPluginAddAuthenticator(&addOptions, &addResponse));
 
         // The response from plugin contains the public key used to sign plugin operation requests. Stash it for later use.
@@ -96,7 +96,7 @@ namespace winrt::PasskeyManager::implementation {
         // Get the function pointer of WebAuthNPluginRemoveAuthenticator
         auto webAuthNPluginRemoveAuthenticator = GetProcAddressByFunctionDeclaration(
             m_webAuthnDll.get(),
-            EXPERIMENTAL_WebAuthNPluginRemoveAuthenticator);
+            WebAuthNPluginRemoveAuthenticator);
         RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginRemoveAuthenticator);
 
         RETURN_HR(webAuthNPluginRemoveAuthenticator(c_pluginClsid));
@@ -106,19 +106,19 @@ namespace winrt::PasskeyManager::implementation {
     {
         // Reset the plugin state and registration status
         m_pluginRegistered = false;
-        m_pluginState = EXPERIMENTAL_PLUGIN_AUTHENTICATOR_STATE::PluginAuthenticatorState_Unknown;
+        m_pluginState = PLUGIN_AUTHENTICATOR_STATE::PluginAuthenticatorState_Unknown;
 
-        // Get handle to EXPERIMENTAL_WebAuthNPluginGetAuthenticatorState which takes in a GUID and returns EXPERIMENTAL_PLUGIN_AUTHENTICATOR_STATE
+        // Get handle to WebAuthNPluginGetAuthenticatorState which takes in a GUID and returns PLUGIN_AUTHENTICATOR_STATE
         auto webAuthNPluginGetAuthenticatorState = GetProcAddressByFunctionDeclaration(
             m_webAuthnDll.get(),
-            EXPERIMENTAL_WebAuthNPluginGetAuthenticatorState);
+            WebAuthNPluginGetAuthenticatorState);
         RETURN_HR_IF_NULL(E_FAIL, webAuthNPluginGetAuthenticatorState);
 
         // Get the plugin state
-        EXPERIMENTAL_PLUGIN_AUTHENTICATOR_STATE localPluginState;
+        PLUGIN_AUTHENTICATOR_STATE localPluginState;
         RETURN_IF_FAILED(webAuthNPluginGetAuthenticatorState(c_pluginClsid, &localPluginState));
 
-        // If the EXPERIMENTAL_WebAuthNPluginGetAuthenticatorState function succeeded, that indicates the plugin is registered and localPluginState is the valid plugin state
+        // If the WebAuthNPluginGetAuthenticatorState function succeeded, that indicates the plugin is registered and localPluginState is the valid plugin state
         m_pluginRegistered = true;
         m_pluginState = localPluginState;
         return S_OK;

--- a/Samples/PasskeyManager/cpp/PluginManagement/PluginRegistrationManager.h
+++ b/Samples/PasskeyManager/cpp/PluginManagement/PluginRegistrationManager.h
@@ -52,13 +52,13 @@ namespace winrt::PasskeyManager::implementation
             return m_pluginRegistered;
         }
 
-        EXPERIMENTAL_PLUGIN_AUTHENTICATOR_STATE GetPluginState() const
+        PLUGIN_AUTHENTICATOR_STATE GetPluginState() const
         {
             return m_pluginState;
         }
 
     private:
-        EXPERIMENTAL_PLUGIN_AUTHENTICATOR_STATE m_pluginState;
+        PLUGIN_AUTHENTICATOR_STATE m_pluginState;
         bool m_initialized = false;
         bool m_pluginRegistered = false;
         wil::unique_hmodule m_webAuthnDll;

--- a/Samples/PasskeyManager/cpp/PluginManagement/PluginRegistrationManager.h
+++ b/Samples/PasskeyManager/cpp/PluginManagement/PluginRegistrationManager.h
@@ -52,13 +52,13 @@ namespace winrt::PasskeyManager::implementation
             return m_pluginRegistered;
         }
 
-        PLUGIN_AUTHENTICATOR_STATE GetPluginState() const
+        AUTHENTICATOR_STATE GetPluginState() const
         {
             return m_pluginState;
         }
 
     private:
-        PLUGIN_AUTHENTICATOR_STATE m_pluginState;
+        AUTHENTICATOR_STATE m_pluginState;
         bool m_initialized = false;
         bool m_pluginRegistered = false;
         wil::unique_hmodule m_webAuthnDll;

--- a/Samples/PasskeyManager/cpp/pch.h
+++ b/Samples/PasskeyManager/cpp/pch.h
@@ -52,5 +52,6 @@
 #include <shlobj_core.h>
 
 #include <include/webauthn/webauthn.h>
+#include <include/webauthn/webauthnplugin.h>
 
 std::vector<uint8_t> hexStringToBytes(const std::string& hex);


### PR DESCRIPTION
### Description
Adressing #408, I'm trying my best to update the sample after the experimental API has been discontinued and the official API is available.

Since it has been some time since I worked with C++, feedback is highly appreciated!

### Open points
- [x] fix deletion of `LPCWSTR`s in `PluginCredentialDetailsDeleter`
- [x] address removal of `EXPERIMENTAL_WEBAUTHN_PLUGIN_CREDENTIAL_DETAILS_LIST`