### PR TITLE
CloudMirror: Add x64 support and update for Visual Studio 2026

### DIFF
--- a/Samples/CloudMirror/CloudMirror.sln
+++ b/Samples/CloudMirror/CloudMirror.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2000
+# Visual Studio 18
+VisualStudioVersion = 18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CloudMirror", "CloudMirror\CloudMirror.vcxproj", "{93C711E5-7D66-45DC-9658-4323CE0892B0}"
 EndProject

--- a/Samples/CloudMirror/CloudMirror/CloudMirror.vcxproj
+++ b/Samples/CloudMirror/CloudMirror/CloudMirror.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.220110.5\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.220110.5\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -32,6 +32,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' &gt;= '18.0'">v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
@@ -154,13 +155,13 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.220110.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.220110.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.220110.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.220110.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.220110.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.220110.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
 </Project>

--- a/Samples/CloudMirror/CloudMirror/packages.config
+++ b/Samples/CloudMirror/CloudMirror/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.220110.5" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
 </packages>

--- a/Samples/CloudMirror/CloudMirrorPackage/CloudMirrorPackage.wapproj
+++ b/Samples/CloudMirror/CloudMirrorPackage/CloudMirrorPackage.wapproj
@@ -35,14 +35,14 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>1fab5d02-237c-4b9c-b820-2eb7c3b6e63a</ProjectGuid>
-    <TargetPlatformVersion>10.0.22598.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <PackageCertificateKeyFile>CloudMirrorPackage_TemporaryKey.pfx</PackageCertificateKeyFile>
     <EntryPointProjectUniqueName>..\CloudMirror\CloudMirror.vcxproj</EntryPointProjectUniqueName>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
-    <AppxBundlePlatforms>x86</AppxBundlePlatforms>
+    <AppxBundlePlatforms>x86|x64</AppxBundlePlatforms>
     <AppInstallerUpdateFrequency>1</AppInstallerUpdateFrequency>
     <AppInstallerCheckForUpdateFrequency>OnApplicationRun</AppInstallerCheckForUpdateFrequency>
   </PropertyGroup>

--- a/Samples/CloudMirror/CloudMirrorPackage/Package.appxmanifest
+++ b/Samples/CloudMirror/CloudMirrorPackage/Package.appxmanifest
@@ -23,7 +23,7 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.18362.0" MaxVersionTested="10.0.22598.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.18362.0" MaxVersionTested="10.0.26100.0" />
   </Dependencies>
 
   <Resources>

--- a/Samples/CloudMirror/README.md
+++ b/Samples/CloudMirror/README.md
@@ -31,7 +31,7 @@ The following functionality is implemented:
 
 **Note**   The Windows-classic-samples repo contains a variety of code samples that exercise the various programming models, platforms, features, and components available in Windows and/or Windows Server. This repo provides a Visual Studio solution (SLN) file for each sample, along with the source files, assets, resources, and metadata needed to compile and run the sample. For more info about the programming models, platforms, languages, and APIs demonstrated in these samples, check out the documentation on the [Windows Dev Center](https://dev.windows.com). This sample is provided as-is in order to indicate or demonstrate the functionality of the programming models and feature APIs for Windows and/or Windows Server.
 
-This sample was created for Windows 10 Version 1809 using Visual Studio and the Windows SDK 10.0.22598.0, but in many cases it will run unaltered using later versions. Please provide feedback on this sample!
+This sample was created for Windows 10 Version 1809 using Visual Studio and the Windows SDK 10.0.22598.0. It is compatible with Visual Studio 2019, 2022, and 2026, and supports both x86 and x64 configurations. Please provide feedback on this sample!
 
 To get a copy of Windows, go to [Downloads and tools](http://go.microsoft.com/fwlink/p/?linkid=301696).
 
@@ -59,11 +59,11 @@ Windows 10 Version 1809
 
 ## Build the sample
 
-Currently the sample is configured for an x86 configuration. Change the solution platform to x86.
+The sample supports both x86 and x64 configurations. Select your desired platform (x86 or x64) in the solution platform dropdown.
 
-To build this sample, open the solution (*.sln*) file titled *CloudMirror.sln* from Visual Studio Professional 2017, Select **CloudMirrorPackage** as the startup project. go to **Build** \> **Build Solution** from the top menu after the sample has loaded.
+To build this sample, open the solution (*.sln*) file titled *CloudMirror.sln* from Visual Studio 2019 or later (including Visual Studio 2022 and 2026), Select **CloudMirrorPackage** as the startup project. go to **Build** \> **Build Solution** from the top menu after the sample has loaded.
 
-**Warning**  This sample requires the Windows SDK 10.0.17763.0.
+**Warning**  This sample requires the Windows SDK 10.0.22598.0 or higher.
 
 ## Run the sample
 


### PR DESCRIPTION
## Summary
Updates the Cloud Mirror sample to support x64 builds and modern Visual Studio versions (2019, 2022, 2026), while maintaining backward compatibility.

## Changes
 
 ### x64 platform support
 - Updated `AppxBundlePlatforms` from `x86` to `x86|x64` in the packaging project, enabling MSIX package generation for both architectures.
 
 ### Visual Studio 2026 compatibility
 - Added `PlatformToolset` conditional for VS 2026 (`v145` when `VisualStudioVersion >= 18.0`), alongside the existing `v142` (VS 2019) default and `v143` (VS 2022) conditional.
 - Updated solution file header to Visual Studio 18.
 
 ### SDK and dependency updates
 - Updated `TargetPlatformVersion` from `10.0.22598.0` to `10.0.26100.0` (Windows SDK 10.0.26100.0).
 - Updated `MaxVersionTested` in `Package.appxmanifest` to `10.0.26100.0`.
 - Upgraded `Microsoft.Windows.CppWinRT` NuGet package from `2.0.220110.5` to `2.0.250303.1`.
 
 ### README updates
 - Replaced x86-only build instructions with x86/x64 guidance.
 - Updated Visual Studio version references from VS 2017 to VS 2019/2022/2026.
 - Corrected minimum SDK version from `10.0.17763.0` to `10.0.22598.0` (matching the existing compile-time check in `stdafx.h`).
 
 ## Backward compatibility
 
 The project remains buildable with Visual Studio 2019 (`v142` default toolset) and Visual Studio 2022 (`v143` conditional). The `MinimumVisualStudioVersion` is unchanged at `10.0.40219.1`.
 
 ## Testing
 
 Verified successful builds for both x86 and x64 (Debug and Release) on Visual Studio 2026 (v18.3, MSBuild 18.3.0, toolset v145).